### PR TITLE
Update leaderboard-generation.yml schedule for weekly execution

### DIFF
--- a/.github/workflows/leaderboard-generation.yml
+++ b/.github/workflows/leaderboard-generation.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 10 0 * 0' # 2am PST every Sunday
+    - cron: '0 10 * * 0' # 2am PST every Sunday
 
 jobs:
   build:


### PR DESCRIPTION
Adjusted the cron schedule in leaderboard-generation.yml to ensure the leaderboard updates at 2 AM PST every Sunday.
Modified the scheduling format to correct the execution timing.