### PR TITLE
Bug: UnboundLocalError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,8 @@ slim-leaderboard = 'jpl.slim.leaderboard:main'
 path = 'src/jpl/slim/VERSION.txt'
 pattern = '(?P<version>.+)'
 
-
 [tool.hatch.build.targets.wheel]
 packages = ['src/jpl']
-
 
 [build-system]
 requires = ['hatchling']

--- a/src/jpl/slim/leaderboard.py
+++ b/src/jpl/slim/leaderboard.py
@@ -391,11 +391,11 @@ def main():
 
                 if isinstance(org_repos, list) and all(isinstance(repo, dict) for repo in org_repos):
                     for repo in org_repos:
+                        repo_name = repo.get('name')
                         if (repo['archived'] or repo['disabled']):  # ignore archived and disabled repositories
                             logging.warning(f"Ignoring archived or disabled repository [{ repo_name }] in org ({ org_url })")
                             continue
                         else:
-                            repo_name = repo.get('name')
                             if repo_name:
                                 repos_list.append(f"https://{base_url}/{org_name}/{repo_name}")
                 else:


### PR DESCRIPTION
## Purpose
Fix the UnboundLocalError that occurs when processing organization repositories that are archived or disabled.

## Proposed Changes
- [FIX] Move the assignment of `repo_name = repo.get('name')` before it's used in warning log message
- [FIX] Ensure the repo_name variable is always defined before being referenced in warning logs

## Issues
- Fixes #31 - UnboundLocalError when processing organization repositories

## Testing
- Tested by installing the package in editable mode and running with the example configuration:
  ```
  slim-leaderboard examples/slim-maap-config.json
  ```
- Successfully processed the configuration without any UnboundLocalError`